### PR TITLE
RemoveDependencyModuler

### DIFF
--- a/src/WebApplication/project.json
+++ b/src/WebApplication/project.json
@@ -20,10 +20,7 @@
       "version": "1.0.0-rc2-3002702",
       "type": "platform"
     },
-    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0-rc2-final",
-    "WebApplication.ExtensionA": "1.0.0",
-    "WebApplication.ExtensionB": "1.0.0",
-    "WebApplication.ExtensionB.Data.EntityFramework.Sqlite": "1.0.0"
+    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0-rc2-final"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
1.try command.

```
dotnet restore
dotnet build
dotnet publish
```

 or `dotnet publish --configuration Release`

2.You set Enviroment.

`dotnet WebApplication.dll`

result:
  But `WebApplication.dll` depend on Modulers `ExtentionA` and `ExtentionB`
  Extensions folder will be meaningless .

solve a problem:
  Did removed from dependencies.
